### PR TITLE
Correct Deprecation Warnings When Running Specs

### DIFF
--- a/lib/signalfx.rb
+++ b/lib/signalfx.rb
@@ -1,6 +1,6 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
-require_relative 'signalfx/conf'
+require_relative 'signalfx/rbconf'
 require_relative 'signalfx/protobuf_signal_fx_client'
 require_relative 'signalfx/json_signal_fx_client'
 
@@ -21,9 +21,9 @@ module SignalFx
   # @param timeout - number
   # @param batch_size - number
   # @param user_agents - array
-  def self.new(api_token, enable_aws_unique_id: false, ingest_endpoint: Config::DEFAULT_INGEST_ENDPOINT,
-      timeout: Config::DEFAULT_TIMEOUT,
-      batch_size: Config::DEFAULT_BATCH_SIZE, user_agents: [])
+  def self.new(api_token, enable_aws_unique_id: false, ingest_endpoint: RbConfig::DEFAULT_INGEST_ENDPOINT,
+      timeout: RbConfig::DEFAULT_TIMEOUT,
+      batch_size: RbConfig::DEFAULT_BATCH_SIZE, user_agents: [])
     begin
       require_relative './proto/signal_fx_protocol_buffers.pb'
       ProtoBufSignalFx.new(api_token, enable_aws_unique_id: enable_aws_unique_id, ingest_endpoint: ingest_endpoint,

--- a/lib/signalfx/json_signal_fx_client.rb
+++ b/lib/signalfx/json_signal_fx_client.rb
@@ -1,7 +1,7 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
 require_relative './signal_fx_client'
-require_relative './conf'
+require_relative './rbconf'
 require 'json'
 
 class JsonSignalFx < SignalFxClient
@@ -9,7 +9,7 @@ class JsonSignalFx < SignalFxClient
   protected
 
   def header_content_type
-    Config::JSON_HEADER_CONTENT_TYPE
+    RbConfig::JSON_HEADER_CONTENT_TYPE
   end
 
   def add_to_queue(metric_type, datapoint)

--- a/lib/signalfx/protobuf_signal_fx_client.rb
+++ b/lib/signalfx/protobuf_signal_fx_client.rb
@@ -1,7 +1,7 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
 require 'thread'
-require_relative './conf'
+require_relative './rbconf'
 require_relative './signal_fx_client'
 require_relative '../proto/signal_fx_protocol_buffers.pb'
 
@@ -10,7 +10,7 @@ class ProtoBufSignalFx < SignalFxClient
   protected
 
   def header_content_type
-    Config::PROTOBUF_HEADER_CONTENT_TYPE
+    RbConfig::PROTOBUF_HEADER_CONTENT_TYPE
   end
 
 

--- a/lib/signalfx/rbconf.rb
+++ b/lib/signalfx/rbconf.rb
@@ -1,6 +1,6 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
-module Config
+module RbConfig
 # Default Parameters
   DEFAULT_INGEST_ENDPOINT = 'https://ingest.signalfx.com'
   DEFAULT_BATCH_SIZE = 300 # Will wait for this many requests before posting

--- a/lib/signalfx/signal_fx_client.rb
+++ b/lib/signalfx/signal_fx_client.rb
@@ -1,7 +1,7 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
 require_relative './version'
-require_relative './conf'
+require_relative './rbconf'
 
 require 'net/http'
 require 'uri'
@@ -27,9 +27,9 @@ class SignalFxClient
 
   $event_categories = EVENT_CATEGORIES
 
-  def initialize(api_token, enable_aws_unique_id: false, ingest_endpoint: Config::DEFAULT_INGEST_ENDPOINT,
-                 timeout: Config::DEFAULT_TIMEOUT,
-                 batch_size: Config::DEFAULT_BATCH_SIZE, user_agents: [])
+  def initialize(api_token, enable_aws_unique_id: false, ingest_endpoint: RbConfig::DEFAULT_INGEST_ENDPOINT,
+                 timeout: RbConfig::DEFAULT_TIMEOUT,
+                 batch_size: RbConfig::DEFAULT_BATCH_SIZE, user_agents: [])
 
     @api_token = api_token
     @ingest_endpoint = ingest_endpoint
@@ -154,7 +154,7 @@ class SignalFxClient
     }
 
     if @aws_unique_id
-      data[:dimensions][Config::AWS_UNIQUE_ID_DIMENSION_NAME] = @aws_unique_id
+      data[:dimensions][RbConfig::AWS_UNIQUE_ID_DIMENSION_NAME] = @aws_unique_id
     end
 
     post(build_event(data), @ingest_endpoint, EVENT_ENDPOINT_SUFFIX)
@@ -224,7 +224,7 @@ class SignalFxClient
 
   def retrieve_aws_unique_id(&block)
     begin
-      RestClient::Request.execute(method: :get, url: Config::AWS_UNIQUE_ID_URL,
+      RestClient::Request.execute(method: :get, url: RbConfig::AWS_UNIQUE_ID_URL,
                                   timeout: 1) { |response|
         case response.code
           when 200
@@ -247,7 +247,7 @@ class SignalFxClient
           if datapoint[:dimensions] == nil
             datapoint[:dimensions] = []
           end
-          datapoint[:dimensions] << {:key => Config::AWS_UNIQUE_ID_DIMENSION_NAME, :value => @aws_unique_id}
+          datapoint[:dimensions] << {:key => RbConfig::AWS_UNIQUE_ID_DIMENSION_NAME, :value => @aws_unique_id}
         end
 
         add_to_queue(metric_type, datapoint)

--- a/spec/signalfx_spec.rb
+++ b/spec/signalfx_spec.rb
@@ -43,7 +43,7 @@ describe 'SignalFx(Fabric method)' do
 
   it 'should be created JsonSignalFx client when Protobuf initialize failed' do
     #Mock ProtoBufSignalFx to thrown Excebtion
-    ProtoBufSignalFx.stub(:new).and_raise(Exception)
+    expect(ProtoBufSignalFx).to receive(:new).and_raise(Exception)
 
     @subject = SignalFx.new TOKEN
 


### PR DESCRIPTION
This commit address the two deprecation warnings (one related to the use of the Config module vs. the newer RbConfig, and one related to the use of RSpec 2 "should" syntax instead of RSpec 3 "expects" syntax) when running the specs.
