### PR TITLE
Do not puts "initialize end" when using aws unique id

### DIFF
--- a/lib/signalfx/signal_fx_client.rb
+++ b/lib/signalfx/signal_fx_client.rb
@@ -53,7 +53,6 @@ class SignalFxClient
         end
       }
     end
-    puts('initialize end')
   end
 
   #Send the given metrics to SignalFx synchronously.


### PR DESCRIPTION
I don't think having this puts does much good. It just seems to clutter up the log file output on startup.
