### PR TITLE
Support Rails 5.x by using rest-client 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     signalfx (1.0.1)
       protobuf (~> 3.5.1, >= 3.5.1)
-      rest-client (~> 1.8)
+      rest-client (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +27,9 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     middleware (0.1.0)
-    mime-types (2.99.3)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     minitest (5.9.0)
     netrc (0.11.0)
     protobuf (3.5.5)
@@ -36,10 +38,10 @@ GEM
       thor
       thread_safe
     rake (10.4.2)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -83,4 +85,4 @@ DEPENDENCIES
   webmock (~> 2.1)
 
 BUNDLED WITH
-   1.10.6
+   1.13.1

--- a/signalfx.gemspec
+++ b/signalfx.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "webmock", "~> 2.1"
   spec.add_dependency "protobuf", "~> 3.5.1", ">= 3.5.1"
-  spec.add_dependency "rest-client", "~> 1.8"
+  spec.add_dependency "rest-client", "~> 2.0"
 end


### PR DESCRIPTION
The current version of this library does not work with Rails 5.x because it requires an older dependency. For example:

```
Bundler could not find compatible versions for gem "mime-types":
  In snapshot (Gemfile.lock):
    mime-types (= 3.1)

  In Gemfile:
    rails (~> 5.0.0.1) was resolved to 5.0.0.1, which depends on
      actionmailer (= 5.0.0.1) was resolved to 5.0.0.1, which depends on
        mail (>= 2.5.4, ~> 2.5) was resolved to 2.6.4, which depends on
          mime-types (< 4, >= 1.16)

    signalfx was resolved to 0.1.0, which depends on
      rest-client (~> 1.8) was resolved to 1.8.0, which depends on
        mime-types (< 3.0, >= 1.16)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

This PR updates rest-client to their 2.x version which resolves the issue.
