### PR TITLE
Removing extraneous EM require statement

### DIFF
--- a/lib/signalfx/signalflow/websocket.rb
+++ b/lib/signalfx/signalflow/websocket.rb
@@ -3,7 +3,6 @@
 require 'json'
 require 'thread'
 require 'websocket-client-simple'
-require 'eventmachine'
 
 require_relative './binary'
 require_relative './channel'


### PR DESCRIPTION
EM was used in a previous iteration of the websocket client but the current client does not use it so we can just remove all references to it.  Our tests do use EM for the fake server.

Fixes #20.