### PR TITLE
Allow protobuf gem to be higher then 3.x.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     signalfx (2.0.2)
-      protobuf (~> 3.5.1, >= 3.5.1)
+      protobuf (>= 3.5.1)
       rest-client (~> 2.0)
       websocket-client-simple (~> 0.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.4)
+    activesupport (5.1.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -32,16 +32,17 @@ GEM
     hashdiff (0.3.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.8.6)
-    json (1.8.3)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    json (1.8.6)
     method_source (0.8.2)
     middleware (0.1.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    minitest (5.10.3)
+    minitest (5.11.3)
     netrc (0.11.0)
-    protobuf (3.5.5)
+    protobuf (3.8.1)
       activesupport (>= 3.2)
       middleware
       thor
@@ -82,16 +83,16 @@ GEM
       rack (>= 1, < 3)
     thor (0.20.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
     webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.4)
+    websocket (1.2.5)
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
@@ -114,4 +115,4 @@ DEPENDENCIES
   webmock (~> 2.1)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/signalfx.gemspec
+++ b/signalfx.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "thin", "~> 1.7"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "faye-websocket", "~> 0.10.7"
-  spec.add_dependency "protobuf", "~> 3.5.1", ">= 3.5.1"
+  spec.add_dependency "protobuf", ">= 3.5.1"
   spec.add_dependency "rest-client", "~> 2.0"
   spec.add_dependency 'websocket-client-simple', "~> 0.3.0"
 end


### PR DESCRIPTION
Hello sginalfx maintainers! Thanks for this gem, it is pretty straightforward to use.

I am creating this PR because I have some other dependencies in my project that requires protobuf 4.0.0 or higher, it makes signalfx gem to be incompatible the way it is released now.

Can you please take a look if it is possible to allow protobuf in more recent versions?

Some more context:
I tried to run the spec tests in my local env, it has failed partially (same results for both protobuf 3.5.1 or 4.x.x.)

Probably because I don't have access here:
```
  host = '127.0.5.55'
  port = 23456
```

I really appreciate to have your review on that.

Thanks