### PR TITLE
Use fake SignalFlow address of 127.0.0.1

### DIFF
--- a/spec/signalflow_spec.rb
+++ b/spec/signalflow_spec.rb
@@ -31,7 +31,7 @@ def wait_for_messages(count=1, timeout=10, &block)
 end
 
 describe 'SignalFlow (Websocket)' do
-  host = '127.0.5.55'
+  host = '127.0.0.1'
   port = 23456
   sf = nil
   kill_server = nil


### PR DESCRIPTION
Linux was fine with the old address, but MacOS likes to block all other
localhost addresses for some reason.