### PR TITLE
Add immediate flag

### DIFF
--- a/examples/signalflow.rb
+++ b/examples/signalflow.rb
@@ -21,11 +21,13 @@ puts
 signalflow = client.signalflow()
 
 signalflow.execute("data('cpu.utilization').publish()").each_message do |msg, comp|
-  case msg[:type]
-  when "data"
-    puts "#{'Host'.center(40, ' ')} | cpu.utilization"
-    msg[:data].each do |tsid,value|
-      puts "#{comp.metadata[tsid][:host][0..40].center(40, ' ')} | #{value}"
+  unless msg.nil?
+    case msg[:type]
+    when "data"
+      puts "#{'Host'.center(40, ' ')} | cpu.utilization"
+      msg[:data].each do |tsid,value|
+        puts "#{comp.metadata[tsid][:host][0..40].center(40, ' ')} | #{value}"
+      end
     end
   end
   puts ""

--- a/lib/signalfx/signalflow/client.rb
+++ b/lib/signalfx/signalflow/client.rb
@@ -34,12 +34,13 @@ class SignalFlowClient
   # @option options [Fixnum] :resolution
   # @option options [Fixnum] :max_delay
   # @option options [Boolean] :persistent
+  # @option options [Boolean] :immediate
   #
   # @return [Computation] A {Computation} instance with an active channel
   def execute(program, **options)
     @transport.execute(program, **options)
   end
-  
+
   # Start and attach to a computation that tells how many times a detector
   # would have fired in a time range between `start` and `stop`.
   #

--- a/lib/signalfx/signalflow/websocket.rb
+++ b/lib/signalfx/signalflow/websocket.rb
@@ -82,7 +82,7 @@ class SignalFlowWebsocketTransport
     end
   end
 
-  def execute(program, start: nil, stop: nil, resolution: nil, max_delay: nil, persistent: nil)
+  def execute(program, start: nil, stop: nil, resolution: nil, max_delay: nil, persistent: nil, immediate: false)
     start_job do |channel_name|
       send_msg({
         :type => "execute",
@@ -93,6 +93,7 @@ class SignalFlowWebsocketTransport
         :resolution => resolution,
         :max_delay => max_delay,
         :persistent => persistent,
+        :immediate => immediate,
         :compress => @compress,
       }.reject!{|k,v| v.nil?}.to_json)
     end
@@ -313,4 +314,3 @@ class SignalFlowWebsocketTransport
   end
   private :make_new_channel
 end
-


### PR DESCRIPTION
When immediate is set to true, the stop time will be automatically adjusted to allow for the immediate
delivery of the computation output.

Used examples/signalflow.rb (with immediate flag set to true and false) for testing