### PR TITLE
Update gemspec and installation instructions for older Ruby versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     signalfx (2.0.5)
+      activesupport (>= 3.2)
       protobuf (>= 3.5.1)
       rest-client (~> 2.0)
       websocket-client-simple (~> 0.3.0)
@@ -9,9 +10,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.5)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
@@ -23,7 +24,7 @@ GEM
     daemons (1.2.4)
     diff-lcs (1.2.5)
     docile (1.3.1)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     event_emitter (0.2.6)
     eventmachine (1.2.5)
@@ -33,17 +34,17 @@ GEM
     hashdiff (0.3.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.9.5)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     method_source (0.8.2)
     middleware (0.1.0)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     minitest (5.11.3)
     netrc (0.11.0)
-    protobuf (3.8.1)
+    protobuf (3.8.4)
       activesupport (>= 3.2)
       middleware
       thor
@@ -94,7 +95,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.5)
+    websocket (1.2.8)
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
@@ -117,4 +118,4 @@ DEPENDENCIES
   webmock (~> 2.3.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Or install it yourself as:
 
     $ gem install signalfx
 
+#### Installing with Ruby 2.2.0 and 2.2.1
+
+This library's protobuf dependency requires activesupport >=3.2.  5.x versions of activesupport require Ruby >=2.2.2,
+so users of older Ruby versions will need to install activesupport 4.2.10 before signalfx to avoid attempts of
+installing a more recent gem.  Building and installing signalfx from source will fulfill this for you:
+
+    $ gem build signalfx.gemspec && gem install signalfx-<current_version>.gem
+
 ## Usage
 
 ### API access token

--- a/signalfx.gemspec
+++ b/signalfx.gemspec
@@ -36,6 +36,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "thin", "~> 1.7"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "faye-websocket", "~> 0.10.7"
+
+  # protobuf enforces this check but builds with a newer Ruby version so it's not enabled.
+  # Incorporating here to allow 2.2.0-1 users to successfully build and install signalfx.
+  active_support_max_version = "< 5" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
+  spec.add_dependency "activesupport", '>= 3.2', active_support_max_version
+
   spec.add_dependency "protobuf", ">= 3.5.1"
   spec.add_dependency "rest-client", "~> 2.0"
   spec.add_dependency 'websocket-client-simple', "~> 0.3.0"


### PR DESCRIPTION
Updating readme for users of Ruby 2.2.0/1.  I've opted for documentation over the ["hack" from protobuf](https://github.com/ruby-protobuf/protobuf/blob/master/protobuf.gemspec#L22) because its propagation requires either
1. Building our gem on an early and EOL version, at the expense of Ruby users who need activesupport 5.x.
2. Documenting that these users should build a gem, which only accomplishes what is added here but with more overhead.