### PR TITLE
Move the Version module to SignalFx::Version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    signalfx (2.0.4)
+    signalfx (2.0.5)
       protobuf (>= 3.5.1)
       rest-client (~> 2.0)
       websocket-client-simple (~> 0.3.0)

--- a/lib/signalfx/signal_fx_client.rb
+++ b/lib/signalfx/signal_fx_client.rb
@@ -208,7 +208,7 @@ class SignalFxClient
 
       headers = {HEADER_CONTENT_TYPE => header_content_type,
                  HEADER_API_TOKEN_KEY => @api_token,
-                 HEADER_USER_AGENT_KEY => Version::NAME + '/' + Version::VERSION + http_user_agents}
+                 HEADER_USER_AGENT_KEY => SignalFx::Version::NAME + '/' + SignalFx::Version::VERSION + http_user_agents}
 
       RestClient::Request.execute(
           method: :post,

--- a/lib/signalfx/version.rb
+++ b/lib/signalfx/version.rb
@@ -1,6 +1,8 @@
 # Copyright (C) 2015-2016 SignalFx, Inc. All rights reserved.
 
-module Version
-  VERSION = '2.0.4'
-  NAME = 'signalfx-ruby-client'
+module SignalFx
+  module Version
+    VERSION = '2.0.5'
+    NAME = 'signalfx-ruby-client'
+  end
 end

--- a/signalfx.gemspec
+++ b/signalfx.gemspec
@@ -5,7 +5,7 @@ require_relative 'lib/signalfx/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "signalfx"
-  spec.version       = Version::VERSION
+  spec.version       = SignalFx::Version::VERSION
   spec.authors       = ["SignalFx, Inc"]
   spec.email         = ["info@signalfx.com"]
 

--- a/spec/signalfx_spec.rb
+++ b/spec/signalfx_spec.rb
@@ -70,7 +70,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://custom-ingest.endpoint/v2/datapoint").
         with(:body => "{\"gauge\":[{\"metric\":\"test.cpu\",\"value\":1,\"dimensions\":{}}],\"counter\":[{\"metric\":\"cpu_cnt\",\"value\":2,\"dimensions\":{}}]}",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -95,7 +95,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://custom-ingest.endpoint/v2/event").
         with(:body => "[{\"category\":\"USER_DEFINED\",\"eventType\":\"deployments\",\"dimensions\":{\"host\":\"myhost\",\"service\":\"myservice\",\"instance\":\"myinstance\"},\"properties\":{\"version\":\"12345\"},\"timestamp\":1234567890}]",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -112,7 +112,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => "{\"gauge\":[{\"metric\":\"test.cpu\",\"value\":1,\"dimensions\":{}}],\"counter\":[{\"metric\":\"cpu_cnt\",\"value\":2,\"dimensions\":{}}]}",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -125,7 +125,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => "{\"gauge\":[{\"metric\":\"test.cpu\",\"value\":1.1,\"dimensions\":{}}],\"counter\":[{\"metric\":\"cpu_cnt\",\"value\":2.2,\"dimensions\":{}}]}",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -138,7 +138,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => "{\"gauge\":[{\"metric\":\"test.cpu\",\"value\":\"111\",\"dimensions\":{}}],\"counter\":[{\"metric\":\"cpu_cnt\",\"value\":\"222\",\"dimensions\":{}}]}",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -151,7 +151,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => "{\"gauge\":[{\"metric\":\"test.cpu\",\"value\":1,\"timestamp\":1234567890,\"dimensions\":{}}],\"counter\":[{\"metric\":\"cpu_cnt\",\"value\":2,\"timestamp\":1234567890,\"dimensions\":{}}]}",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -164,7 +164,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => "{\"gauge\":[{\"metric\":\"test.cpu\",\"value\":1,\"dimensions\":{\"host\":\"server1\",\"host_ip\":\"1.2.3.4\"}}],\"counter\":[{\"metric\":\"cpu_cnt\",\"value\":2,\"dimensions\":{\"host\":\"server1\",\"host_ip\":\"1.2.3.4\"}}]}",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -183,7 +183,7 @@ describe 'SignalFx(JSON mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/event").
         with(:body => "[{\"category\":\"USER_DEFINED\",\"eventType\":\"deployments\",\"dimensions\":{\"host\":\"myhost\",\"service\":\"myservice\",\"instance\":\"myinstance\"},\"properties\":{\"version\":\"12345\"},\"timestamp\":1234567890}]",
-             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/json', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -213,7 +213,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://custom-ingest.endpoint/v2/datapoint").
         with(:body => StringIO.new("\n\x10\x12\btest.cpu\"\x02\x18\x01(\x00\n\x0F\x12\acpu_cnt\"\x02\x18\x02(\x01").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -232,7 +232,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://custom-ingest.endpoint/v2/datapoint").
         with(:body => StringIO.new("\n\x10\x12\btest.cpu\"\x02\x18\x01(\x00\n\x0F\x12\acpu_cnt\"\x02\x18\x02(\x01").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -258,7 +258,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://custom-ingest.endpoint/v2/event").
         with(:body => StringIO.new("\ni\n\vdeployments\x12\x0E\n\x04host\x12\x06myhost\x12\x14\n\aservice\x12\tmyservice\x12\x16\n\binstance\x12\nmyinstance\x1A\x12\n\aversion\x12\a\n\x0512345 \xC0\x84=(\xD2\x85\xD8\xCC\x04").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + ', ua_1, ua_2', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -271,7 +271,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => StringIO.new("\n\x10\x12\btest.cpu\"\x02\x18\x01(\x00\n\x0F\x12\acpu_cnt\"\x02\x18\x02(\x01").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -284,7 +284,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => StringIO.new("\n\x17\x12\btest.cpu\"\t\x11\x9A\x99\x99\x99\x99\x99\xF1?(\x00\n\x16\x12\acpu_cnt\"\t\x11\x9A\x99\x99\x99\x99\x99\x01@(\x01").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type'=>'application/x-protobuf', 'User-Agent'=>'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token'=>TOKEN,
+             :headers => {'Content-Type'=>'application/x-protobuf', 'User-Agent'=>'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token'=>TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK")
 
@@ -297,7 +297,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => StringIO.new("\n\x13\x12\btest.cpu\"\x05\n\x03111(\x00\n\x12\x12\acpu_cnt\"\x05\n\x03111(\x01").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -310,7 +310,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => StringIO.new("\n\x16\x12\btest.cpu\x18\xD2\x85\xD8\xCC\x04\"\x02\x18\x01(\x00\n\x15\x12\acpu_cnt\x18\xD2\x85\xD8\xCC\x04\"\x02\x18\x02(\x01").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -323,7 +323,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/datapoint").
         with(:body => StringIO.new("\n5\x12\btest.cpu\"\x02\x18\x01(\x002\x0F\n\x04host\x12\aserver12\x12\n\ahost_ip\x12\a1.2.3.4\n4\x12\acpu_cnt\"\x02\x18\x02(\x012\x0F\n\x04host\x12\aserver12\x12\n\ahost_ip\x12\a1.2.3.4").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
@@ -342,7 +342,7 @@ describe 'SignalFx(Protobuf mode)' do
 
     stub_request(:post, "https://ingest.signalfx.com/v2/event").
         with(:body => StringIO.new("\ni\n\vdeployments\x12\x0E\n\x04host\x12\x06myhost\x12\x14\n\aservice\x12\tmyservice\x12\x16\n\binstance\x12\nmyinstance\x1A\x12\n\aversion\x12\a\n\x0512345 \xC0\x84=(\xD2\x85\xD8\xCC\x04").set_encoding('ascii-8bit').string,
-             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + Version::VERSION + '', 'X-Sf-Token' => TOKEN,
+             :headers => {'Content-Type' => 'application/x-protobuf', 'User-Agent' => 'signalfx-ruby-client/' + SignalFx::Version::VERSION + '', 'X-Sf-Token' => TOKEN,
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 


### PR DESCRIPTION
While integrating this signalfx library into a Rails project I'm working on, I found the
non-namespaced Version collides with generated Thrift code in the rbhive
gem.  While both of these gems could be fixed, this version module being
scoped under a namespace felt more correct than fixing generated code.

For reference the conflicting rbhive code can be found here: https://github.com/forward3d/rbhive/blob/master/lib/thrift/hive_metastore_types.rb#L29

They conflict because the SignalFX Version is a module and the rbhive Version is a class... though I wouldn't really want them mingling anyhow.

This seems a simple enough fix, though I'm happy to do it another way.  Please let me know if there are any changes or any additional information you'd like to see.