### PR TITLE
pass stream_endpoint to constructor, remove api_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optional constructor parameters:
   deployed on Amazon AWS.
 + **ingest_endpoint** (string): to override the target ingest API
   endpoint.
-+ **api_endpoint** (string): to override the target REST API endpoint.
++ **stream_endpoint** (string): to override the target stream endpoint for SignalFlow.
 + **timeout** (number): timeout, in seconds, for requests to SignalFx.
 + **batch_size** (number): size of datapoint batches to send to
   SignalFx.

--- a/lib/signalfx.rb
+++ b/lib/signalfx.rb
@@ -16,13 +16,14 @@ module SignalFx
   #     and set it as `AWSUniqueId` dimension for each datapoint and event.
   #     Use this option only if your application deployed to Amazon
   # @param ingest_endpoint - string
-  # @param api_endpoint - string
+  # @param stream_endpoint - string
   # @param timeout - number
   # @param batch_size - number
   # @param user_agents - array
   def self.new(api_token,
                enable_aws_unique_id: false,
                ingest_endpoint: RbConfig::DEFAULT_INGEST_ENDPOINT,
+               stream_endpoint: RbConfig::DEFAULT_STREAM_ENDPOINT,
                timeout: RbConfig::DEFAULT_TIMEOUT,
                batch_size: RbConfig::DEFAULT_BATCH_SIZE,
                user_agents: [],
@@ -32,6 +33,7 @@ module SignalFx
       ProtoBufSignalFx.new(api_token,
                            enable_aws_unique_id: enable_aws_unique_id,
                            ingest_endpoint: ingest_endpoint,
+                           stream_endpoint: stream_endpoint,
                            timeout: timeout,
                            batch_size: batch_size,
                            user_agents: user_agents)
@@ -42,6 +44,7 @@ module SignalFx
       JsonSignalFx.new(api_token,
                        enable_aws_unique_id: enable_aws_unique_id,
                        ingest_endpoint: ingest_endpoint,
+                       stream_endpoint: stream_endpoint,
                        timeout: timeout,
                        batch_size: batch_size,
                        user_agents: user_agents)

--- a/lib/signalfx/signal_fx_client.rb
+++ b/lib/signalfx/signal_fx_client.rb
@@ -31,7 +31,6 @@ class SignalFxClient
   def initialize(api_token,
                  enable_aws_unique_id: false,
                  ingest_endpoint: RbConfig::DEFAULT_INGEST_ENDPOINT,
-                 api_endpoint: RbConfig::DEFAULT_API_ENDPOINT,
                  stream_endpoint: RbConfig::DEFAULT_STREAM_ENDPOINT,
                  timeout: RbConfig::DEFAULT_TIMEOUT,
                  batch_size: RbConfig::DEFAULT_BATCH_SIZE,
@@ -40,7 +39,6 @@ class SignalFxClient
 
     @api_token = api_token
     @ingest_endpoint = ingest_endpoint
-    @api_endpoint = api_endpoint
     @stream_endpoint = stream_endpoint
     @timeout = timeout
     @batch_size = batch_size
@@ -174,7 +172,7 @@ class SignalFxClient
   # @return [SignalFlowClient] a newly instantiated client, configured with the
   #   api token and endpoints from this class
   def signalflow
-    SignalFlowClient.new(@api_token, @api_endpoint, @stream_endpoint)
+    SignalFlowClient.new(@api_token, @stream_endpoint)
   end
 
   protected

--- a/lib/signalfx/signalflow/client.rb
+++ b/lib/signalfx/signalflow/client.rb
@@ -19,7 +19,7 @@ require_relative "./websocket"
 # our API reference for SignalFlow}.  Hash keys will be symbols instead of
 # strings.
 class SignalFlowClient
-  def initialize(api_token, api_endpoint, stream_endpoint)
+  def initialize(api_token, stream_endpoint)
     @transport = SignalFlowWebsocketTransport.new(api_token, stream_endpoint)
   end
 


### PR DESCRIPTION
Just needed to pass down the stream_endpoint to the client constructors. api_endpoint is never used.