### PR TITLE
Rename instances of `send` to `transmit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ require('signalfx')
 
 client = SignalFx.new 'MY_SIGNALFX_TOKEN'
 
-client.send(
+client.transmit(
            cumulative_counters:[
              {  :metric => 'myfunc.calls_cumulative',
                 :value => 10,
@@ -141,7 +141,7 @@ require('signalfx')
 
 client = SignalFx.new 'MY_SIGNALFX_TOKEN'
 
-client.send(
+client.transmit(
           cumulative_counters:[
             {   :metric => 'myfunc.calls_cumulative',
                 :value => 10,
@@ -167,7 +167,7 @@ reporting data.
 
 ### Sending events
 
-Events can be sent to SignalFx via the `send_event()` function. The
+Events can be sent to SignalFx via the `transmit_event()` function. The
 event type must be specified, and dimensions and extra event properties
 can be supplied as well. Also please specify event category: for that
 get option from dictionary `EVENT_CATEGORIES`. Different categories of
@@ -181,7 +181,7 @@ timestamp = (Time.now.to_i * 1000).to_i
 
 client = SignalFx.new 'MY_SIGNALFX_TOKEN'
 
-client.send_event(
+client.transmit_event(
     '<event_type>',
     event_category: '<event_category>',
     dimensions: { host: 'myhost',

--- a/examples/generic_usecase.rb
+++ b/examples/generic_usecase.rb
@@ -25,7 +25,7 @@ while true do
   gauges = [{:metric => 'test.cpu', :value => counter % 10, :timestamp => timestamp}]
   counters = [{:metric => 'cpu_cnt', :value => counter % 2, :timestamp => timestamp}]
 
-  client.send(gauges: gauges, counters: counters)
+  client.transmit(gauges: gauges, counters: counters)
 
   if counter % 100 == 0
     event_type = 'deployments'
@@ -37,7 +37,7 @@ while true do
     properties = {version: version}
 
     event_category = SignalFxClient::EVENT_CATEGORIES[:ALERT]
-    client.send_event(event_type, event_category: event_category, dimensions: dimensions, properties: properties)
+    client.transmit_event(event_type, event_category: event_category, dimensions: dimensions, properties: properties)
   end
 
   counter +=1

--- a/lib/signalfx/signalflow/websocket.rb
+++ b/lib/signalfx/signalflow/websocket.rb
@@ -85,7 +85,7 @@ class SignalFlowWebsocketTransport
 
   def execute(program, start: nil, stop: nil, resolution: nil, max_delay: nil, persistent: nil, immediate: false)
     start_job do |channel_name|
-      send_msg({
+      transmit_msg({
         :type => "execute",
         :channel => channel_name,
         :program => program,
@@ -102,7 +102,7 @@ class SignalFlowWebsocketTransport
 
   def preflight(program, start, stop, resolution: nil, max_delay: nil)
     start_job do |channel_name|
-      send_msg({
+      transmit_msg({
         :type => "preflight",
         :channel => channel_name,
         :program => program,
@@ -117,7 +117,7 @@ class SignalFlowWebsocketTransport
 
   def start(program, start: nil, stop: nil, resolution: nil, max_delay: nil)
     start_job do |channel_name|
-      send_msg({
+      transmit_msg({
         :type => "start",
         :channel => channel_name,
         :program => program,
@@ -130,7 +130,7 @@ class SignalFlowWebsocketTransport
   end
 
   def stop(handle, reason)
-    send_msg({
+    transmit_msg({
       :type => "stop",
       :handle => handle,
       :reason => reason,
@@ -141,7 +141,7 @@ class SignalFlowWebsocketTransport
   def attach(handle, filters: nil, resolution: nil)
     channel = make_new_channel
 
-    send_msg({
+    transmit_msg({
       :type => "attach",
       :channel => channel.name,
       :handle => handle,
@@ -154,7 +154,7 @@ class SignalFlowWebsocketTransport
   end
 
   def detach(channel, reason=nil)
-    send_msg({
+    transmit_msg({
       :type => "detach",
       :channel => channel,
       :reason => reason,
@@ -174,7 +174,7 @@ class SignalFlowWebsocketTransport
     end
   end
 
-  def send_msg(msg)
+  def transmit_msg(msg)
     @lock.synchronize do
       if @ws.nil?
         startup_client
@@ -197,7 +197,7 @@ class SignalFlowWebsocketTransport
       @ws.send(msg)
     end
   end
-  private :send_msg
+  private :transmit_msg
 
   def on_close(msg)
     @close_reason = "(#{msg.code}, #{msg.data})"

--- a/spec/signalfx_spec.rb
+++ b/spec/signalfx_spec.rb
@@ -13,7 +13,7 @@ describe 'SignalFxClient(a.k.a abstract class)' do
     counters = [{:metric => 'cpu_cnt', :value => 2}]
 
     expect {
-      @subject.send(gauges: gauges, counters: counters)
+      @subject.transmit(gauges: gauges, counters: counters)
     }.to raise_error(RuntimeError)
   end
 
@@ -27,7 +27,7 @@ describe 'SignalFxClient(a.k.a abstract class)' do
     properties = {version: version}
 
     expect {
-      @subject.send_event(event_type, dimensions: dimensions, properties: properties)
+      @subject.transmit_event(event_type, dimensions: dimensions, properties: properties)
     }.to raise_error(RuntimeError)
   end
 end
@@ -74,7 +74,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    client.send(gauges: gauges, counters: counters)
+    client.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should be send event with all params' do
@@ -99,7 +99,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    client.send_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
+    client.transmit_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
   end
 
   it 'should be instance of SignalFxClient class' do
@@ -116,7 +116,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct float value' do
@@ -129,7 +129,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct string value' do
@@ -142,7 +142,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct data with timestamp' do
@@ -155,7 +155,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct data with dimensions' do
@@ -168,7 +168,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send event' do
@@ -187,7 +187,7 @@ describe 'SignalFx(JSON mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
+    @subject.transmit_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
   end
 end
 
@@ -217,7 +217,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    client.send(gauges: gauges, counters: counters)
+    client.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should be send datapoints with all params async' do
@@ -236,7 +236,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    client.send_async(gauges: gauges, counters: counters)
+    client.transmit_async(gauges: gauges, counters: counters)
     sleep(0.5)
   end
 
@@ -262,7 +262,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    client.send_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
+    client.transmit_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
   end
 
   it 'should send correct int value' do
@@ -275,7 +275,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct float value' do
@@ -288,7 +288,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK")
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct string value' do
@@ -301,7 +301,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct data with timestamp' do
@@ -314,7 +314,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send correct data with dimensions' do
@@ -327,7 +327,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send(gauges: gauges, counters: counters)
+    @subject.transmit(gauges: gauges, counters: counters)
   end
 
   it 'should send event' do
@@ -346,7 +346,7 @@ describe 'SignalFx(Protobuf mode)' do
                           'Accept' => /.*/, 'Accept-Encoding' => /.*/, 'Content-Length' => /\d+/}).
         to_return(:status => 200, :body => "OK", :headers => {})
 
-    @subject.send_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
+    @subject.transmit_event(event_type, dimensions: dimensions, properties: properties, timestamp: timestamp)
   end
 end
 
@@ -358,13 +358,13 @@ describe 'SignalFx(General)' do
 
   it 'Send event: throw error when event type is empty' do
     expect {
-      @subject.send_event(nil)
+      @subject.transmit_event(nil)
     }.to raise_error(RuntimeError)
   end
 
   it 'Send event: unsupported event category' do
     expect {
-      @subject.send_event('deployment', event_category: 'TEST')
+      @subject.transmit_event('deployment', event_category: 'TEST')
     }.to raise_error(RuntimeError)
   end
 end


### PR DESCRIPTION
Ruby has an internal method of dispatching messages, which is named
`send`. The client using the same name causes collisions in certain
codebases, so we rename to avoid confusion.

Additionally, most instances of `send_*` are also renamed to
`transmit_*` to maintain consistency.

Addresses https://github.com/signalfx/signalfx-ruby/issues/4