### PR TITLE
Fix broken tci spec ruby 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
-sudo: required
 language: ruby
-dist: trusty
+dist: xenial
+os: linux
+
+# See: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install -v '< 2'
 
 rvm:
   - 2.2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os: linux
 # See: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install -v '< 2'
+  - gem install bundler -v '< 2'
 
 rvm:
   - 2.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.4)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -60,19 +60,19 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
     safe_yaml (1.0.4)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -107,7 +107,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.10)
+  bundler (~> 1.17.3)
   faye-websocket (~> 0.10.7)
   pry
   rake (~> 10.0)
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (~> 2.3.1)
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/signalfx.gemspec
+++ b/signalfx.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 1.17.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "webmock", "~> 2.3.1"


### PR DESCRIPTION
Ruby 2.5.5 specs are broken on Travis CI. This PR addresses the issue, which is the default `bundler` version is now `2.x`, but to support pre-`2.3.x` rubies, we use the last of the `1.X` `bundler` gem.

This restriction can be removed when support of Ruby < `2.3` is dropped.